### PR TITLE
Fix #1: Spaces in Hollywood executable are not escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ This is a complete example of a task definition:
     "label": "Run Hollywood Main script",
     "type": "shell",
     "command": "${config:hollywood.exePath}",
-    "args":["${workspaceFolder}/${config:hollywood.mainFile}"],
+    "args":["${config:hollywood.mainFile}"],
     "group": {
         "kind": "build",
         "isDefault": true

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ This is a complete example of a task definition:
 {
     "label": "Run Hollywood Main script",
     "type": "shell",
-    "command": "${config:hollywood.exePath} ${workspaceFolder}/${config:hollywood.mainFile}",
+    "command": "${config:hollywood.exePath}",
+    "args":["${workspaceFolder}/${config:hollywood.mainFile}"],
     "group": {
         "kind": "build",
         "isDefault": true

--- a/exampleFiles/tasks.json
+++ b/exampleFiles/tasks.json
@@ -7,7 +7,7 @@
             "label": "Run Hollywood Main script",
             "type": "shell",
             "command": "${config:hollywood.exePath}",
-            "args": ["${workspaceFolder}/${config:hollywood.mainFile}"],
+            "args": ["$${config:hollywood.mainFile}"],
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -17,14 +17,14 @@
             "label": "Run Hollywood Main script (nodebug)",
             "type": "shell",
             "command": "${config:hollywood.exePath}",
-            "args":["${workspaceFolder}/${config:hollywood.mainFile}",
+            "args":["${config:hollywood.mainFile}",
                     "-nodebug"]
         },
         {
             "label": "Compile Hollywood Main script to default target",
             "type": "shell",
             "command": "${config:hollywood.exePath}",
-            "args": ["${workspaceFolder}/${config:hollywood.mainFile}",
+            "args": ["${config:hollywood.mainFile}",
                 "-compile",
                 "${fileBasenameNoExtension}",
                 "-exetype",

--- a/exampleFiles/tasks.json
+++ b/exampleFiles/tasks.json
@@ -6,7 +6,8 @@
         {
             "label": "Run Hollywood Main script",
             "type": "shell",
-            "command": "${config:hollywood.exePath} ${workspaceFolder}/${config:hollywood.mainFile}",
+            "command": "${config:hollywood.exePath}",
+            "args": ["${workspaceFolder}/${config:hollywood.mainFile}"],
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -15,22 +16,35 @@
         {
             "label": "Run Hollywood Main script (nodebug)",
             "type": "shell",
-            "command": "${config:hollywood.exePath} ${workspaceFolder}/${config:hollywood.mainFile} -nodebug"
+            "command": "${config:hollywood.exePath}",
+            "args":["${workspaceFolder}/${config:hollywood.mainFile}",
+                    "-nodebug"]
         },
         {
             "label": "Compile Hollywood Main script to default target",
             "type": "shell",
-            "command": "${config:hollywood.exePath} ${workspaceFolder}/${config:hollywood.mainFile} -compile ${fileBasenameNoExtension} -exetype ${config:hollywood.outputExeTypes}"
+            "command": "${config:hollywood.exePath}",
+            "args": ["${workspaceFolder}/${config:hollywood.mainFile}",
+                "-compile",
+                "${fileBasenameNoExtension}",
+                "-exetype",
+                "${config:hollywood.outputExeTypes}"]
         },
         {
             "label": "Run the currently opened Hollywood script",
             "type": "shell",
-            "command": "${config:hollywood.exePath} ${file} "
+            "command": "${config:hollywood.exePath}",
+            "args": ["${file}"]
         },
         {
             "label": "Compile the currently opened Hollywood file to multiple targets ",
             "type": "shell",
-            "command": "${config:hollywood.exePath} ${file} -compile ${fileBasenameNoExtension} -exetype win64|classic|morphos"
+            "command": "${config:hollywood.exePath}",
+            "args": ["${file}",
+                "-compile",
+                "${fileBasenameNoExtension}",
+                "-exetype",
+                "win64|classic|morphos"]
         }
     ]
 }

--- a/exampleFiles/tasks.json
+++ b/exampleFiles/tasks.json
@@ -7,7 +7,7 @@
             "label": "Run Hollywood Main script",
             "type": "shell",
             "command": "${config:hollywood.exePath}",
-            "args": ["$${config:hollywood.mainFile}"],
+            "args": ["${config:hollywood.mainFile}"],
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
Here's a suggested fix, to break the command and arguments in separate fields.
This way, VSCode takes care of any spaces necessary and the command works properly.