### PR TITLE
bugfix: multiple exetypes in task.json

### DIFF
--- a/exampleFiles/tasks.json
+++ b/exampleFiles/tasks.json
@@ -55,7 +55,7 @@
                 "-compile",
                 "${fileBasenameNoExtension}",
                 "-exetype",
-                "win64|classic|morphos"
+                "'win64|classic|morphos'"
             ]
         }
     ]


### PR DESCRIPTION
Updated `tasks.json` to fix a problem with multiple exetypes